### PR TITLE
Fix comments and jsdoc, remove cardCompareTrump

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,35 +1,24 @@
 import type * as t from './types'
+
 /**
- * Some common functions we can use for working with cards.
+ * @param card1 - the first card
+ * @param card2 - the second card
+ * @param trump - which suit is trump. Optional
+ *
+ * @returns Positive if the first card (`card1`) is greater,
+ *          negative if the second card (`card2`) is greater,
+ *          and `0` if they are equal rank. Any card can that is
+ *          not trump can be beaten by any trump card. Trump cards
+ *          are compared by subtracting rank, as are any non-trump
+ *          cards. If no trump is specified, we just compare cards.
  */
-
-export function cardCompare(card1: t.Card, card2: t.Card): t.ordering {
-    /**
-     * @param card1 - the first card
-     * @param card2 - the second card
-     *
-     * @returns Positive if the first card (`card1`) is greater,
-     *          negative if the second card (`card2`) is greater,
-     *          and `0` if they are equal rank.
-     */
+export function cardCompare(card1: t.Card, card2: t.Card, trump?: t.Suit): t.ordering {
+    if (trump) {
+        if (card1.suit == trump && card2.suit != trump) {
+            return 1
+        } else if (card2.suit == trump && card1.suit != trump) {
+            return -1
+        }
+    }
     return card1.rank - card2.rank
-}
-
-export function cardCompareTrump(card1: t.Card, card2: t.Card, trump: t.Suit = "spades"): t.ordering {
-    /**
-     * @param card1 - the first card
-     * @param card2 - the second card
-     * @param trump - which suit is trump. Default: `"spades"`
-     *
-     * @returns Positive if the first card (`card1`) is greater,
-     *          negative if the second card (`card2`) is greater,
-     *          and `0` if they are equal rank. Any card can that is
-     *          not trump can be beaten by any trump card. Trump cards
-     *          are compared with cardCompare, as are any non-trump cards.
-     */
-    if (card1.suit == trump && card2.suit != trump) {
-        return 1
-    } else if (card2.suit == trump && card1.suit != trump) {
-        return -1
-    } else return cardCompare(card1, card2)
 }

--- a/src/deck.ts
+++ b/src/deck.ts
@@ -1,13 +1,13 @@
 import type * as t from './types'
 
+/**
+ * Sets up the deck for the players
+ *
+ * @param players - the number of players in the game
+ * @param startingCard - what rank of card to start the deck from. default: 6
+ * @param cardsPerPlayer - number of cards for each player. default: 6
+ */
 export class Deck {
-    /**
-     * Sets up the deck for the players
-     *
-     * @param players - the number of players in the game
-     * @param startingCard - what rank of card to start the deck from. default: 6
-     * @param cardsPerPlayer - number of cards for each player. default: 6
-     */
     readonly players: number
     readonly startingCard: t.Rank
     readonly cardsPerPlayer: number

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -1,19 +1,12 @@
 import type * as t from '../src/types'
-import { cardCompare, cardCompareTrump } from '../src/common'
+import { cardCompare } from '../src/common'
 
-    // let d = new deck.Deck(2, 6, 6)
-test('compares cards', () => {
-    let c1: t.Card = {rank: 2, suit: "clubs"}
-    let c2: t.Card = {rank: 6, suit: "clubs"}
-    expect(cardCompare(c1, c2)).toBeLessThan(0)
-})
-
-test('compare cards with trump', () => {
+test('compare cards', () => {
     let c1: t.Card = {rank: 2, suit: "hearts"}
     let c2: t.Card = {rank: 6, suit: "clubs"}
     let c3: t.Card = {rank: 3, suit: "hearts"}
-    expect(cardCompareTrump(c1, c2, "hearts")).toBeGreaterThan(0)
-    expect(cardCompareTrump(c2, c1, "hearts")).toBeLessThan(0)
-    expect(cardCompareTrump(c1, c3, "hearts")).toBeLessThan(0)
-    expect(cardCompareTrump(c1, c3)).toBeLessThan(0)
+    expect(cardCompare(c1, c2, "hearts")).toBeGreaterThan(0)  // trump v non-trump
+    expect(cardCompare(c2, c1, "hearts")).toBeLessThan(0)  // non-trump v trump
+    expect(cardCompare(c1, c3, "hearts")).toBeLessThan(0)  // trump v trump
+    expect(cardCompare(c1, c3)).toBeLessThan(0) // no trump set
 })

--- a/test/deck.test.ts
+++ b/test/deck.test.ts
@@ -3,7 +3,7 @@ import type { Card } from "../src/types"
 
 test('card count', () => {
     let d1 = new Deck(4)
-    expect(d1.deck.length).toEqual(11)
+    expect(d1.deck.length).toEqual(11)  // 36 - 24 = 12, minus one for final trump
     expect(d1.hands.length).toEqual(4)
     expect(d1.hands[0].length).toEqual(6)
     expect(d1.hands[3].length).toEqual(6)


### PR DESCRIPTION
Python has taught me to put docs inside the functions, jsdoc puts them outside.

Made `cardCompare` more general, trump is optional and turns it into the old `cardCompareTrump`.

<!-- Bug fixes and new features should include tests and possibly benchmarks. -->

##### Checklist

- [x] `npm install && npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->